### PR TITLE
refactor Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,34 @@
-PKG_PREFIX := github.com/balerter/balerter
-TAG := latest # $(shell git describe --tag)
+PKG_PREFIX  :=  github.com/balerter/balerter
+TAG         ?=  latest
 
-.PHONY: build-balerter
+.PHONY: help\
+	build-balerter push-balerter gobuild-balerter\
+	build-tgtool push-tgtool\
+	test-full test-integration
+
 build-balerter: ## Build balerter docker image
 	@echo Build Balerter $(TAG)
 	docker build --build-arg version=$(TAG) -t balerter/balerter:$(TAG) -f ./contrib/balerter.Dockerfile .
 
-.PHONY: push-balerter
 push-balerter: ## Build balerter image to docker registry
 	@echo Push Balerter $(TAG)
 	docker push balerter/balerter:$(TAG)
 
-.PHONY: gobuild-balerter
 gobuild-balerter: ## Build balerter binary file
 	@echo Go Build Balerter
 	go build -o ./.debug/balerter -ldflags "-X main.revision=${TAG} -s -w" ./cmd/balerter
 
-.PHONY: build-tgtool
 build-tgtool: ## Build tgtool docker image
 	@echo Build tgtool
 	docker build -t balerter/tgtool:$(TAG) -f ./contrib/tgtool.Dockerfile .
 
-.PHONY: push-tgtool
 push-tgtool: ## Build tgtool image to docker registry
 	@echo Push tgtool $(TAG)
 	docker push balerter/tgtool:$(TAG)
 
-.PHONY: test-full
 test-full: ## Run full tests
 	GO111MODULE=on go test -mod=vendor -coverprofile=coverage.txt -covermode=atomic ./internal/... ./cmd/...
 
-.PHONY: test-integration
 test-integration: ## Run integration tests
 	go build -race -o ./balerter ./cmd/balerter
 	docker-compose -f ./test/docker-compose.yml up -d
@@ -41,8 +39,5 @@ test-integration: ## Run integration tests
 
 
 # Absolutely awesome: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
-.PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
-
-.DEFAULT_GOAL := build-balerter

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL       =   /bin/sh
 PKG_PREFIX  :=  github.com/balerter/balerter
 TAG         ?=  latest
 

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ PKG_PREFIX  :=  github.com/balerter/balerter
 TAG         ?=  latest
 
 .SUFFIXES:
-.PHONY: help\
-	build-balerter push-balerter gobuild-balerter\
-	build-tgtool push-tgtool\
+.PHONY: help \
+	build-balerter push-balerter gobuild-balerter \
+	build-tgtool push-tgtool \
 	test-full test-integration
 
 build-balerter: ## Build balerter docker image

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL       =   /bin/sh
 PKG_PREFIX  :=  github.com/balerter/balerter
 TAG         ?=  latest
 
+.SUFFIXES:
 .PHONY: help\
 	build-balerter push-balerter gobuild-balerter\
 	build-tgtool push-tgtool\


### PR DESCRIPTION
* move all `.Phony` to one multi-line assignment
* remove `.DEFAULT_GOAL`, because `build-balerter` already default
  target by order
* remove `TAG` inline comment, because it adds trailing spaces on variable
  assignment
* add `SHELL` recommended by best practices of make
* add `SUFFIXES` it reset all default suffixes, recommended

