### PR TITLE
pass fields to labels

### DIFF
--- a/internal/channels/alertmanager/send.go
+++ b/internal/channels/alertmanager/send.go
@@ -39,6 +39,9 @@ func (a *AlertManager) Send(mes *message.Message) error {
 
 	promAlert.Labels["name"] = mes.AlertName
 	promAlert.Annotations["description"] = mes.Text
+	for k, v := range mes.Fields {
+		promAlert.Labels[k] = v
+	}
 
 	data, err := json.Marshal([]*modelAlert{promAlert})
 	if err != nil {

--- a/internal/channels/alertmanager/send_test.go
+++ b/internal/channels/alertmanager/send_test.go
@@ -101,6 +101,7 @@ func TestSend(t *testing.T) {
 		AlertName: "",
 		Text:      "",
 		Image:     "",
+		Fields:    map[string]string{"foo": "bar"},
 	}
 
 	err := a.Send(mes)


### PR DESCRIPTION
The current alertmanager implementation ignores any passed fields. This MR will pass an alerts fields to alertmanager labels.